### PR TITLE
Mko/componentsui forminput

### DIFF
--- a/client/src/components-ui/form-input/FormInput.js
+++ b/client/src/components-ui/form-input/FormInput.js
@@ -1,0 +1,19 @@
+import React, { } from 'react';
+import style from './form-input.module.scss';
+
+// *************************** FORM INPUT COMPONENT *************************** //
+const FormInput = ({ small, onChange, ...otherProps }) => {
+  // destructured props passed down via parent component (size / onChange handler / otherProps)
+  return (
+    <input 
+      className={`
+        ${small ? style.small : ''}
+        ${style.input}
+      `}
+      onChange={onChange}
+      {...otherProps}
+    />
+  )
+};
+
+export default FormInput;

--- a/client/src/components-ui/form-input/form-input.module.scss
+++ b/client/src/components-ui/form-input/form-input.module.scss
@@ -1,0 +1,24 @@
+@import '../../styles/global.styles';
+
+// FORM INPUT
+.input {
+  height: 3rem;
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0 0.5rem;
+
+  // SMALL
+  &.small {
+    width: 10rem;
+    height: 2rem;
+    font-size: 1.2rem;
+    margin-bottom: 0;
+  }
+}
+
+// ********************************** MEDIA QUERIES ********************************** //
+@media screen and (min-width: 500px) {
+  .input {
+    width: 25rem;
+  }
+}


### PR DESCRIPTION
### Description

Add FormInput.js + styling module to components-ui folder. This will be used as a universal form input throughout the app

### Changes

- Add form-input folder to components-ui folder
- Add FormInput.js -- contains component logic
- Add form-input.module.scss -- contains component styling

### Verification

![image](https://user-images.githubusercontent.com/21230325/66142983-6d3c3300-e5d4-11e9-938d-4f57a3359432.png)

### Trello Link

https://trello.com/c/DOIhLwGe/19-create-common-ui-components

### Notes

- Currently only 1 differing size 'small' which will be used in the header / navbar.
- Baseline form width = 100% (will take on the length of the parent container)
