### PR TITLE
Fix typo in setupTests.js -- 'adapter'

### DIFF
--- a/client/src/tests/setupTests.js
+++ b/client/src/tests/setupTests.js
@@ -2,5 +2,5 @@ import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 configure({
-  adapater: new Adapter(),
+  adapter: new Adapter(),
 });


### PR DESCRIPTION
### Description

Fix typo in test folder -> setupTests.js -> 'adapater' to 'adapter'

### Changes

Fix typo in test folder -> setupTests.js -> 'adapater' to 'adapter'

### Verification

![image](https://user-images.githubusercontent.com/21230325/66226113-09833a00-e6a8-11e9-8e15-dacd5d9821d3.png)

### Trello Link

n/a

### Notes

n/a
