### PR TITLE
Add auth middleware and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "createdb": "createdb -O postgres -U postgres skynet",
     "createdb-test": "createdb -O postgres -U postgres skynet-test",
     "server": "nodemon -r dotenv/config src/server.js dotenv_config_path=./config/.env.local",
-    "test": "jest --watch --i"
+    "test": "jest --watch --i --verbose"
   },
   "jest": {
     "setupFiles": [

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,41 @@
+const jwt = require('jsonwebtoken')
+const User = require('../models/User')
+
+/**
+ * This middleware checks that any routes requiring authorization
+ * get a valid jsonwebtoken passed in the request header.
+ * 
+ * If a valid token is provided, the user object will be extracted from
+ * the token payload and attached to the request so it is accessible
+ * in the protected endpoint.
+ */
+
+module.exports = async function(req, res, next) {
+  // get token from req header
+  const token = req.header('x-auth-token')
+
+  // check for no token in header
+  if (!token) {
+    return res.status(401).json({ msg: 'No token; authorization denied' })
+  }
+
+  try {
+    // cache the user object (payload returned from jwt.verify)
+    const decoded = jwt.verify(token, process.env.JWT_SECRET)
+
+    // confirm id in token payload matches an existing user
+    const user = await User.findOne({ where: { id: decoded.id } })
+    if (!user) throw new Error()
+
+    // remove the password field
+    delete decoded.password
+
+    // attach the user object to the request
+    req.user = decoded
+
+    // call next to proceed to the route
+    next()
+  } catch (err) {
+    res.status(401).json({ msg: 'Invalid token; authorization denied' })
+  }
+}

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -3,6 +3,7 @@ const bcrypt = require('bcryptjs')
 const { validationResult } = require('express-validator')
 const router = express.Router()
 const User = require('../models/User')
+const auth = require('../middleware/auth')
 const {
   setAvatar,
   createAuthToken,
@@ -82,9 +83,9 @@ router.post('/login', loginValidatorChecks(), async (req, res) => {
 })
 
 // get all users
-router.get('/', async (req, res) => {
+router.get('/', auth, async (req, res) => {
   try {
-    const users = await User.findAll()
+    let users = await User.findAll({ attributes: { exclude: ['password']}})
 
     res.status(200).json(users)
   } catch (err) {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,51 @@
+const request = require('supertest')
+const app = require('../src/app')
+const User = require('../src/models/User')
+const { syncDatabase, populateTables, sampleUsers } = require('./fixtures/db')
+
+beforeAll(syncDatabase)
+beforeEach(populateTables)
+
+/**
+ * Tests for auth middleware
+ */
+
+test('Should get all users when auth is valid (user is logged in)', async () => {
+  // login a sample user to get an auth token
+  const loginResponse = await request(app)
+    .post('/users/login')
+    .send({
+      email: sampleUsers[0].email,
+      password: sampleUsers[0].password
+    })
+
+  // send req to auth protected endpoint
+  const response = await request(app)
+    .get('/users')
+    .set('x-auth-token', loginResponse.body.token) // set token header
+    .expect(200) // assert http res code
+
+  // assert res has array with the 3 sample users
+  expect(response.body.length).toBe(3)
+})
+
+test('Should not get any users if no auth token is provided', async () => {
+  // send req to auth protected endpoint; do not set any token header
+  const response = await request(app)
+    .get('/users')
+    .expect(401) // assert http res code
+
+  // assert response message content
+  expect(response.body.msg).toBe('No token; authorization denied')
+})
+
+test('Should not get any users if an invalid token is provided', async () => {
+  // send req to auth protected endpoint; do not provide any token header
+  const response = await request(app)
+    .get('/users')
+    .set('x-auth-token', 'someInvalidToken') // provide invalid token header
+    .expect(401) // assert http res code
+
+  // assert response message content
+  expect(response.body.msg).toBe('Invalid token; authorization denied')
+})


### PR DESCRIPTION
### Description

Add auth middleware and tests

### Changes

- Add auth.js to /src/middleware
- Apply auth middleware to get all users route: GET /users
- Remove password field from user attributes returned by get all users route 

- Add tests.test.js for auth middleware
- Add --verbose option to test script in package.json so we can see list of each test that passes/fails

### Verification

![image](https://user-images.githubusercontent.com/48368341/66425236-276cd980-e9dd-11e9-91a0-1e4ae321dba0.png)

### Trello Link

https://trello.com/c/cu3HqNl7

### Notes

The get all users route is the only route currently implemented that uses authentication. I will add more tests to the auth test suite as more protected routes get implemented.
