### PR TITLE
Cb/utils are friends

### DIFF
--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -4,7 +4,7 @@ const Comment = require('../models/Comment')
 const Post = require('../models/Post')
 const { validationResult } = require('express-validator')
 const auth = require('../middleware/auth')
-const { contentValidatorChecks } = require('../utils/utils')
+const { contentValidatorChecks, areFriends } = require('../utils/utils')
 
 // create new comment
 router.post(
@@ -22,6 +22,13 @@ router.post(
 
       if (!post) {
         return res.status(404).json({ msg: 'Post not found' })
+      }
+
+      // confirm commenter and poster are friends
+      const friends = await areFriends(req.user.id, post.dataValues.user_id)
+
+      if (!friends) {
+        return res.status(401).json({ msg: 'Must be friends to comment on post' })
       }
 
       // insert the comment into the db

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken')
 const gravatar = require('gravatar')
 const User = require('../models/User')
+const Relation = require('../models/Relation')
 const { check } = require('express-validator')
 
 // returns a JsonWebToken as a string
@@ -82,6 +83,29 @@ const formatRelation = (first_user_id, second_user_id, relationType) => {
   return relationData
 }
 
+// return true iff two user ids have a friends relation
+const areFriends = async (first_user_id, second_user_id) => {
+let relationData = {
+    first_user_id,
+    second_user_id,
+    relationType: 'friends'
+  }
+
+  if (first_user_id > second_user_id) {
+    relationData.first_user_id = second_user_id
+    relationData.second_user_id = first_user_id
+  }
+
+  const friends = await Relation.findOne({
+    where: relationData
+  })
+
+  if (!friends) return false
+  
+  return true
+}
+
+
 module.exports = {
   createAuthToken,
   createUser,
@@ -89,5 +113,6 @@ module.exports = {
   loginValidatorChecks,
   contentValidatorChecks,
   setAvatar,
-  formatRelation
+  formatRelation,
+  areFriends
 }

--- a/tests/comments.test.js
+++ b/tests/comments.test.js
@@ -2,6 +2,7 @@ const request = require('supertest')
 const jwt = require('jsonwebtoken')
 const app = require('../src/app')
 const Comment = require('../src/models/Comment')
+const { areFriends } = require('../src/utils/utils')
 const {
   syncDatabase,
   dbPosts,
@@ -14,9 +15,9 @@ beforeEach(syncDatabase)
  * Create new comment endpoint tests
  */
 
-test('Should create a new comment when content is provided and post id is valid', async () => {
+test('Should create a new comment when content is provided, post id is valid, and the two users are friends', async () => {
   const response = await request(app)
-    .post(`/comments/new/${dbPosts[0].id}`)
+    .post(`/comments/new/${dbPosts[3].id}`)
     .set('x-auth-token', tokens[1])
     .send({
       content: 'Wow good job!'
@@ -30,10 +31,37 @@ test('Should create a new comment when content is provided and post id is valid'
   expect(comment.user_id).toEqual(decoded.id)
 
   // assert comment has post id matching req param
-  expect(comment.post_id).toEqual(dbPosts[0].id)
+  expect(comment.post_id).toEqual(dbPosts[3].id)
+
+  // assert the commenter and post owner are friends
+  expect(await areFriends(decoded.id, dbPosts[3].user_id)).toBeTruthy()
 
   // assert response body content to match the post content
   expect(response.body.content).toEqual('Wow good job!')
+})
+
+test('Should not create a new comment the two users are not friends', async () => {
+  const response = await request(app)
+    .post(`/comments/new/${dbPosts[0].id}`)
+    .set('x-auth-token', tokens[1])
+    .send({
+      content: 'Wow good job!'
+    })
+    .expect(401) // assert http res code
+  
+  // cache the req user object from the auth token payload
+  const decoded = jwt.verify(tokens[1], process.env.JWT_SECRET)
+
+  const comment = await Comment.findOne({ where: { content: 'Wow good job!' } })
+
+  // assert no comment with req body content was added to the db
+  expect(comment).toBeNull()
+
+  // assert the commenter and post owner are not friends
+  expect(await areFriends(decoded.id, dbPosts[0].user_id)).toBeFalsy()
+
+  // assert response body content to match the post content
+  expect(response.body.msg).toEqual('Must be friends to comment on post')
 })
 
 test('Should not create a new comment when content is empty', async () => {


### PR DESCRIPTION
### Description

- Implement areFriends utils function to check for friendship
- Add areFriends check in create comment route
- Update tests for create comment to include areFriends check

### Changes

Make a util function to return true iff two users are friends.

Add this to create new comment route. So a user can only comment on a post if the commenter and poster are friends.

Add tests for it after implementing.

We can use this on any route where two users should be friends in order to do some action.

### Verification

![image](https://user-images.githubusercontent.com/48368341/66695304-14ccfb80-ec8e-11e9-8e9d-c34efdb91a70.png)


### Trello Link

[trello link here]

### Notes

[other references]
