### PR TITLE
Cb/self post comment

### DIFF
--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -27,10 +27,11 @@ router.post(
       // confirm commenter and poster are friends
       const friends = await areFriends(req.user.id, post.dataValues.user_id)
 
-      if (!friends) {
+      // only allow friends or post owner to comment
+      if (!friends && req.user.id !== post.dataValues.user_id) {
         return res
           .status(401)
-          .json({ msg: 'Must be friends to comment on post' })
+          .json({ msg: 'Only post owner and friends of owner can comment' })
       }
 
       // insert the comment into the db
@@ -84,7 +85,9 @@ router.delete('/:comment_id', auth, async (req, res) => {
       comment.dataValues.user_id !== req.user.id &&
       post.dataValues.user_id !== req.user.id
     ) {
-      return res.status(401).json({ msg: 'Only post or comment owner can delete comments' })
+      return res
+        .status(401)
+        .json({ msg: 'Only post or comment owner can delete comments' })
     }
 
     // delete the comment from the db


### PR DESCRIPTION
### Description

Patch create comment route to allow post owner to comment on their own posts & tests for patch.

### Changes

Previously only friends of the post owner could comment on a post. And since a user does not have a friend relation to themselves, they couldn't comment on their own post. This patch fixes that.

Updated tests for new patch.

### Verification

![image](https://user-images.githubusercontent.com/48368341/66709851-35528f80-ed3a-11e9-98ab-1f6626d65962.png)

### Trello Link

https://trello.com/c/cu3HqNl7

### Notes

[other references]
