### PR TITLE
Cb/delete post

### DIFF
--- a/src/routes/posts.js
+++ b/src/routes/posts.js
@@ -7,11 +7,11 @@ const { contentValidatorChecks } = require('../utils/utils')
 
 // create new post
 router.post('/new', [auth, contentValidatorChecks()], async (req, res) => {
-    const errors = validationResult(req) // run checks on req
-    if (!errors.isEmpty()) {
-      return res.status(400).json({ errors: errors.array() })
-    }
-  
+  const errors = validationResult(req) // run checks on req
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() })
+  }
+
   try {
     // insert post into the db
     const post = await Post.create({
@@ -33,6 +33,34 @@ router.get('/', auth, async (req, res) => {
     res.status(200).send(posts)
   } catch (err) {
     res.status(400).send(err)
+  }
+})
+
+// delete post
+router.delete('/:post_id', auth, async (req, res) => {
+  try {
+    // confirm post to delete exists in db
+    const post = await Post.findOne({ where: { id: req.params.post_id } })
+
+    if (!post) {
+      return res.status(404).json({ msg: 'Post not found' })
+    }
+
+    // confirm deleter owns the post to delete
+    if (req.user.id !== post.dataValues.user_id) {
+      return res.status(401).json({ msg: 'Cannot delete another users post'})
+    }
+
+    // delete the post from the db
+    await post.destroy({ force: true })
+    
+    res.status(200).json({ msg: 'Post deleted' })
+  } catch (err) {
+    if (err.message.match(/^(invalid input syntax for integer)/)) {
+      // this message will trigger if non integer is put in req param
+      return res.status(400).json({ msg: 'Post not found' })
+    }
+    res.status(500).send('Server Error')
   }
 })
 

--- a/tests/posts.test.js
+++ b/tests/posts.test.js
@@ -2,10 +2,8 @@ const request = require('supertest')
 const jwt = require('jsonwebtoken')
 const app = require('../src/app')
 const Post = require('../src/models/Post')
-const {
-  syncDatabase,
-  tokens
-} = require('./fixtures/db')
+const Comment = require('../src/models/Comment')
+const { syncDatabase, tokens, dbPosts } = require('./fixtures/db')
 
 beforeEach(syncDatabase)
 
@@ -41,4 +39,114 @@ test('Should not create a new post when content is empty', async () => {
 
   // assert response body content to match the post content
   expect(response.body.hasOwnProperty('errors')).toBeTruthy()
+})
+
+/**
+ * Delete post endpoint tests
+ */
+
+test('Should delete post when post id is valid and deleter owns post', async () => {
+  // cache req user object from auth token payload
+  const decoded = jwt.verify(tokens[1], process.env.JWT_SECRET)
+
+  // assert req user owns post to delete
+  expect(decoded.id === dbPosts[1].user_id).toBeTruthy()
+
+  // dbUsers[1] deletes dbPosts[1]
+  const response = await request(app)
+    .delete(`/posts/${dbPosts[1].id}`)
+    .set('x-auth-token', tokens[1])
+    .expect(200) // assert http res code
+
+  // query db for deleted post
+  const post = await Post.findOne({ where: { id: dbPosts[1].id } })
+
+  // assert deleted post is no longer in db
+  expect(post).toBeNull()
+
+  // assert http response msg matches expected
+  expect(response.body.msg).toEqual('Post deleted')
+})
+
+test('Should delete children comments of post when post id is valid and deleter owns post', async () => {
+  // cache req user object from auth token payload
+  const decoded = jwt.verify(tokens[1], process.env.JWT_SECRET)
+
+  // assert req user owns post to delete
+  expect(decoded.id === dbPosts[1].user_id).toBeTruthy()
+
+  // query db for children comments of post to delete
+  let comments = await Comment.findAll({ where: { post_id: dbPosts[1].id } })
+
+  // assert existance of 2 children comments
+  expect(comments.length).toBe(2)
+
+  // dbUsers[1] deletes dbPosts[1]
+  const response = await request(app)
+    .delete(`/posts/${dbPosts[1].id}`)
+    .set('x-auth-token', tokens[1])
+    .expect(200) // assert http res code
+
+  // query db for children comments of deleted post
+  comments = await Comment.findAll({ where: { post_id: dbPosts[1].id } })
+
+  // assert children comments no longer in db
+  expect(comments).toEqual([])
+})
+
+test('Should not delete a post when the deleter does not own post', async () => {
+  // cache the req user object from the auth token payload
+  const decoded = jwt.verify(tokens[1], process.env.JWT_SECRET)
+
+  // assert req user does not own the post to delete
+  expect(decoded.id !== dbPosts[2].user_id)
+
+  // dbUsers[1] deletes dbPosts[2]
+  const response = await request(app)
+    .delete(`/posts/${dbPosts[2].id}`)
+    .set('x-auth-token', tokens[1])
+    .expect(401) // assert http res code
+
+  // query db for attempted deleted post
+  const post = await Post.findOne({
+    where: { id: dbPosts[2].id }
+  })
+
+  // assert post is still in db
+  expect(post).not.toBeNull()
+
+  // assert http response msg to match expected
+  expect(response.body.msg).toEqual(
+    'Cannot delete another users post'
+  )
+})
+
+test('Should send applicable http response when deleting non existant post', async () => {
+  // query db for attempted deleted post
+  const post = await Post.findOne({
+    where: { id: 99 }
+  })
+
+  // assert no post with id: 99 exists in db
+  expect(post).toBeNull()
+
+  // dbUsers[2] deletes post with id: 99
+  const response = await request(app)
+    .delete(`/posts/99`)
+    .set('x-auth-token', tokens[2])
+    .expect(404) // assert http res code
+
+  // assert http response msg to match expected
+  expect(response.body.msg).toEqual('Post not found')
+})
+
+test('Should send applicable http response when delete post id syntax is invalid (non integer)', async () => {
+  // dbUsers[2] deletes post with id: asdf
+  const response = await request(app)
+    .delete(`/posts/asdf`)
+    .set('x-auth-token', tokens[2])
+    .expect(400) // assert http res code
+
+  // assert http response msg to match expected
+  expect(response.body.msg).toEqual('Post not found')
 })


### PR DESCRIPTION
### Description

- Add delete post api route
- Add tests for delete post api route

### Changes

A user can delete their own posts using this route:

DELETE /posts/:post_id

Deleting a post will also delete any children comments on that post regardless of the owner.

### Verification

![image](https://user-images.githubusercontent.com/48368341/66719419-7344c780-edbd-11e9-92eb-e29dab4b2966.png)

### Trello Link

https://trello.com/c/cu3HqNl7

### Notes

