### PR TITLE
Cb/delete account

### DIFF
--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -85,9 +85,24 @@ router.post('/login', loginValidatorChecks(), async (req, res) => {
 // get all users
 router.get('/', auth, async (req, res) => {
   try {
-    let users = await User.findAll({ attributes: { exclude: ['password']}})
+    let users = await User.findAll({ attributes: { exclude: ['password'] } })
 
     res.status(200).json(users)
+  } catch (err) {
+    res.status(500).send('Server Error')
+  }
+})
+
+// delete account
+router.delete('/me', auth, async (req, res) => {
+  try {
+    // query db for req user
+    const user = await User.findOne({ where: { id: req.user.id } })
+
+    // delete user from db
+    await user.destroy()
+
+    res.status(200).json({ msg: 'Hasta la vista, baby' })
   } catch (err) {
     res.status(500).send('Server Error')
   }

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -88,7 +88,7 @@ test('Should not create a new comment if no auth token is provided', async () =>
 })
 
 test('Should not create a new comment if an invalid token is provided', async () => {
-  // send req to auth protected endpoint; do not provide any token header
+  // send req to auth protected endpoint
   const response = await request(app)
     .post('/comments/new/1')
     .set('x-auth-token', 'someInvalidToken') // provide invalid token header
@@ -107,3 +107,23 @@ test('Should not create a new relation if no auth token is provided', async () =
   // assert response message content
   expect(response.body.msg).toBe('No token; authorization denied')
 })
+
+test('Should not delete user when invalid is provided', async () => {
+  // dbusers[0] deletes their account; set invalid token header
+  const response = await request(app)
+    .delete('/users/me')
+    .set('x-auth-token', 'someInvalidToken')
+    .expect(401)
+  
+  expect(response.body.msg).toEqual('Invalid token; authorization denied')
+ })
+
+
+test('Should not delete user when no auth token is provideed', async () => {
+  // dbusers[0] deletes their account; do not set token header
+  const response = await request(app)
+    .delete('/users/me')
+    .expect(401)
+  
+  expect(response.body.msg).toEqual('No token; authorization denied')
+ })


### PR DESCRIPTION
### Description

Add delete account api route and tests

### Changes

- Use this route to delete your account: DELETE /users/me

This will also delete all of your relations, posts, and comments. Your auth token will no longer be valid since your user id is deleted.

The front-end should redirect to a goodbye page or back to the register/login landing.

### Verification

![image](https://user-images.githubusercontent.com/48368341/66725926-13bdda80-ee04-11e9-9ce2-3eb8cf908996.png)

### Trello Link

https://trello.com/c/cu3HqNl7

### Notes

[other references]
