### PR TITLE
Cb/get profile

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -141,6 +141,13 @@ const getFriendRelations = async user_id => {
   return friends
 }
 
+// returns count of a users friends
+const getFriendsCount = async user_id => {
+  const friends = await getFriendRelations(user_id)
+
+  return friends.length
+}
+
 // returns an array integer friend ids of user
 const getFriendIds = async user_id => {
   const friendRelations = await getFriendRelations(user_id)
@@ -185,6 +192,28 @@ const populateFriendsList = async (friendRelations, user_id) => {
   )
 
   return friendsList
+}
+
+// returns array of formatted post objects owned by the param user
+const populateUserPosts = async user_id => {
+  // query db for all ids of posts by self
+  const postIds = await Post.findAll({
+    where: {
+      user_id
+    },
+    order: [['id', 'DESC']],
+    attributes: ['id'],
+    limit: 100
+  })
+
+  // for each post get add the formatted post to the array
+  const userPosts = Promise.all(
+    postIds.map(async postId => {
+      return await getFormattedPost(postId.dataValues.id)
+    })
+  )
+
+  return userPosts
 }
 
 // returns newsfeed array of formatted post objects
@@ -281,7 +310,9 @@ module.exports = {
   areFriends,
   getRelation,
   getFriendRelations,
+  getFriendsCount,
   getFriendIds,
   populateFriendsList,
-  populateNewsFeed
+  populateNewsFeed,
+  populateUserPosts
 }


### PR DESCRIPTION
### Description

Add get profile api route and tests

### Changes

- Add some helper functions in utils:
  - getFreindsCount(): returns number of friends for a user
  - populateUserPosts(): returns a users own formatted posts with comments for display on their profile
- Implement the get profile route: GET /users/profile/:user_id
  - This route is used for all profiles (your own, your friends, non friends).
  - If you get the profile of someone who is not your friend, you only get limited info (name, avatar)
    - ![image](https://user-images.githubusercontent.com/48368341/66965304-2ffd8980-f047-11e9-8e3d-d5a38d2ade1f.png)

  - If you get profile of yourself or a friend you get the full info (name, avatar, bio, number of friends, and all of their posts w/ comments): 
    - ![image](https://user-images.githubusercontent.com/48368341/66965252-07758f80-f047-11e9-9f78-c8883789d45d.png)
- Add tests for the new route

### Verification

![image](https://user-images.githubusercontent.com/48368341/66965218-e44ae000-f046-11e9-8784-fd404f29b8f7.png)

![image](https://user-images.githubusercontent.com/48368341/66965175-c7aea800-f046-11e9-831e-8425f1fcdd9a.png)

### Trello Link

https://trello.com/c/cu3HqNl7

### Notes

[other references]
